### PR TITLE
Use DocBook XSL artifacts from Maven Central

### DIFF
--- a/unix-handbook/build.xml
+++ b/unix-handbook/build.xml
@@ -67,9 +67,9 @@
   </target>
 
   <target name="docbook" depends="init" unless="docbook.unpacked">
-    <unzip src="${org.docbook:docbook-xsl:zip}" dest="target/docbook" overwrite="false"/>
+    <unzip src="${net.sf.docbook:docbook-xsl:zip:ns-resources}" dest="target/docbook" overwrite="false"/>
     <copy todir="${docbook-xsl}">
-      <fileset dir="target/docbook/docbook-xsl-${version.docbook}"/>
+      <fileset dir="target/docbook/docbook"/>
     </copy>
   </target>
 
@@ -183,7 +183,7 @@
         <pathelement location="${saxon:saxon:jar}"/>
         <pathelement location="${xerces:xercesImpl:jar}"/>
         <pathelement location="${net.sf.xslthl:xslthl:jar}"/>
-        <pathelement location="${docbook-xsl}/extensions/saxon65.jar"/>
+        <pathelement location="${net.sf.docbook:docbook-xsl-saxon:jar}"/>
       </classpath>
       <arg value="-o"/>
       <arg value="${basedir}/${style.output}"/>

--- a/unix-handbook/pom.xml
+++ b/unix-handbook/pom.xml
@@ -59,10 +59,16 @@
       <version>2.9.1</version>
     </dependency>
     <dependency>
-      <groupId>org.docbook</groupId>
+      <groupId>net.sf.docbook</groupId>
       <artifactId>docbook-xsl</artifactId>
       <version>${version.docbook}</version>
+      <classifier>ns-resources</classifier>
       <type>zip</type>
+    </dependency>
+    <dependency>
+      <groupId>net.sf.docbook</groupId>
+      <artifactId>docbook-xsl-saxon</artifactId>
+      <version>1.0.1-pre</version>
     </dependency>
     <dependency>
       <groupId>net.sf.xslthl</groupId>


### PR DESCRIPTION
Replaced dependency org.docbook:docbook-xsl:zip:1.75.0 which is not in Maven Central with net.sf.docbook:docbook-xsl:zip:ns-resources:1.75.0 and net.sf.docbook:docbook-xsl-saxon:1.0.1-pre which are. docbook-xsl-saxon replaces extensions/saxon65.jar from the full DocBook XSL distribution.
