### PR TITLE
[MUNIX-44] Fixed <copyFile> doc, <file> is now <path>

### DIFF
--- a/unix-handbook/src/main/docbook/content/handbook.xml
+++ b/unix-handbook/src/main/docbook/content/handbook.xml
@@ -1808,7 +1808,7 @@
 
             <tbody>
               <row>
-                <entry><literal>file</literal></entry>
+                <entry><literal>path</literal></entry>
 
                 <entry>The file to copy</entry>
               </row>
@@ -1837,7 +1837,7 @@
           <title>Example usage of <tag>&lt;copyFile&gt;</tag></title>
 
           <programlisting>&lt;copyFile&gt;
-  &lt;file&gt;src/main/native/myapp.so&lt;/file&gt;
+  &lt;path&gt;src/main/native/myapp.so&lt;/path&gt;
   &lt;toFile&gt;/opt/myapp/myapp.so&lt;/toFile&gt;
   &lt;attributes&gt;
     &lt;user&gt;myapp&lt;/user&gt;


### PR DESCRIPTION
Fixed `<copyFile>` assembly operation documentation so that it reads`<path>` instead of `<file>`. Reported by Davd Hidalgo in [MUNIX-44](http://jira.codehaus.org/browse/MUNIX-44).
