### PR TITLE
RPM %define support attempt

### DIFF
--- a/unix-maven-plugin/src/main/java/org/codehaus/mojo/unix/maven/plugin/RpmSpecificSettings.java
+++ b/unix-maven-plugin/src/main/java/org/codehaus/mojo/unix/maven/plugin/RpmSpecificSettings.java
@@ -38,6 +38,8 @@ public class RpmSpecificSettings
 
     public Option<String> rpmbuild = none();
 
+    public List<String> defineStatements = List.nil();
+
     public void setGroup( String group )
     {
         this.group = fromNull( group );
@@ -46,6 +48,17 @@ public class RpmSpecificSettings
     public void setRpmbuild( String rpmbuild )
     {
         this.rpmbuild = fromNull( rpmbuild );
+    }
+
+    public void setDefineStatements(java.util.List<String> statements)
+    {
+        if (statements == null)
+            return;
+        for (String s : statements)
+        {
+            defineStatements = defineStatements.snoc(s);
+        }
+        defineStatements = defineStatements.nub();
     }
 
     public String toString()

--- a/unix-maven-plugin/src/main/java/org/codehaus/mojo/unix/maven/rpm/RpmMojoUtil.java
+++ b/unix-maven-plugin/src/main/java/org/codehaus/mojo/unix/maven/rpm/RpmMojoUtil.java
@@ -41,6 +41,6 @@ public class RpmMojoUtil
         }
 
         return unixPackage.
-            rpmParameters( rpm.group.some(), rpm.rpmbuild );
+            rpmParameters( rpm.group.some(), rpm.rpmbuild, rpm.defineStatements );
     }
 }

--- a/unix-maven-plugin/src/main/java/org/codehaus/mojo/unix/maven/rpm/RpmUnixPackage.java
+++ b/unix-maven-plugin/src/main/java/org/codehaus/mojo/unix/maven/rpm/RpmUnixPackage.java
@@ -82,10 +82,11 @@ public class RpmUnixPackage
         return this;
     }
 
-    public RpmUnixPackage rpmParameters( String group, Option<String> rpmbuild )
+    public RpmUnixPackage rpmParameters( String group, Option<String> rpmbuild, List<String> defineStatements )
     {
         specFile.group = group;
         this.rpmbuild = rpmbuild;
+        specFile.defineStatements = defineStatements;
         return this;
     }
 

--- a/unix-maven-plugin/src/test/java/org/codehaus/mojo/unix/maven/rpm/RpmUnixPackageTest.java
+++ b/unix-maven-plugin/src/test/java/org/codehaus/mojo/unix/maven/rpm/RpmUnixPackageTest.java
@@ -75,7 +75,7 @@ public class RpmUnixPackageTest
 
         RpmUnixPackage unixPackage = packagingFormat.start( new SystemStreamLog() ).
             parameters( parameters ).
-            rpmParameters( "Fun", Option.<String>none() ).
+            rpmParameters( "Fun", Option.<String>none(), List.<String>nil() ).
             workingDirectory( root.resolve( "working-directory" ) );
 
         unixPackage.beforeAssembly( EMPTY, now );
@@ -110,7 +110,7 @@ public class RpmUnixPackageTest
             {
                 protected RpmUnixPackage extraStuff( RpmUnixPackage rpmUnixPackage )
                 {
-                    return rpmUnixPackage.rpmParameters( "my-group", Option.<String>none() );
+                    return rpmUnixPackage.rpmParameters( "my-group", Option.<String>none(), List.<String>nil() );
                 }
             };
         unixPackageTestUtil.testFiltering();


### PR DESCRIPTION
I can't claim I fully know what I'm doing, but some hacking on the code resulted in what appears to not break things, as the tests pass Let me know your thoughts?

To use the %define support, add in a defineStatements tag with define tags specifying the values to use for %define lines:

```
<configuration>
  <rpm>
    <defineStatements>
      <define>_source_filedigest_algorithm md5</define>
      <define>_binary_filedigest_algorithm md5</define>
      <define>_source_payload w9.gzdio</define>
      <define>_binary_payload w9.gzdio</define>
    </defineStatements>
...
</configuration>
```
